### PR TITLE
ZeroMQ IPC implementation, take two

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /build/*
 *.pyo
 *.pyc
+/api-mongo/*

--- a/Make.rules
+++ b/Make.rules
@@ -8,17 +8,29 @@ LIBPREFIX=lib
 
 SOURCE_SUFIX := cc
 
+ifndef SOURCE_FILES
 SOURCE_FILES := $(wildcard *.$(SOURCE_SUFIX))
+endif
 
 RFLIBS := $(addprefix $(BUILD_LIB_DIR)/,$(RFLIB_NAME))
 RFLIBS := $(addsuffix .$(LIBSUFFIX),$(RFLIBS))
 
 BOOST_LIBS := -lboost_thread -lboost_system -lboost_filesystem -lboost_program_options
-LNX_LIBS := -lrt -lnetlink -lutil -lpthread -lmongoclient $(BOOST_LIBS)
+LNX_LIBS := -lrt -lnetlink -lutil -lpthread
+ifdef USE_ZEROMQ
+LNX_LIBS += -lzmq
+endif
+ifdef USE_MONGO
+LNX_LIBS += -lmongoclient
+endif
+LNX_LIBS += $(BOOST_LIBS)
 
 CPPFLAGS += -I$(LIB_DIR)
+CPPFLAGS += -I$(BUILD_INC_DIR)
 CPPFLAGS += $(addprefix -I$(LIB_DIR)/,$(libdirs))
+ifdef USE_MONGO
 CPPFLAGS += -I$(MONGO_DIR)
+endif
 
 ifneq (,$(DEBUG))
 CFLAGS += -g -D_GLIBCXX_DEBUG=1

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export LIB_DIR=$(ROOT_DIR)/rflib
 export NOX_DIR=$(ROOT_DIR)/nox-rfproxy
 
 # IPC options are zeromq or mongo
-export IPC=mongo
+export IPC=zeromq
 
 ifeq ($(IPC),zeromq)
 export USE_ZEROMQ=1

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ QUIET=1
 
 OVS_VERSION="deb"
 MONGO_VERSION="deb"
+ZMQ_VERSION="3.2.3"
 USE_MONGO=1
 
 RFDIR=`pwd`
@@ -40,7 +41,7 @@ usage() {
     echo "  -s    Build release versions of dependencies"
     echo "  -g    Build git versions of dependencies"
     echo "  -u    Update (rebuild) dependencies even if they have been built"
-    echo "  -z    Do not use MongoDB"
+    echo "  -z    Use ZeroMQ for IPC"
     echo;
     echo "Dependency version options:"
     echo "  Versions can be specified as \"deb\", \"X.Y.Z\" or \"git\""
@@ -105,8 +106,10 @@ parse_opts() {
             p) RFDIR=${OPTARG};;
             v) QUIET=0;;
             d) MONGO_VERSION="deb";
+               # ZMQ_VERSION="deb";  # Requires Ubuntu 13.10+
                OVS_VERSION="deb";;
             g) MONGO_VERSION="git";
+               ZMQ_VERSION="git";
                OVS_VERSION="git";;
             u) UPDATE=1;;
             m) MONGO_VERSION=${OPTARG};;
@@ -171,9 +174,9 @@ main() {
 
     # Import scripts from dist/
     . $RFDIR/dist/common.sh
-    . $RFDIR/dist/build_ovs.sh
-    . $RFDIR/dist/build_mongo.sh
-    . $RFDIR/dist/build_bson.sh
+    for app in ovs mongo bson zmq; do
+        . "$RFDIR/dist/build_$app.sh"
+    done
 
     if [ "$DO" = "echo" ]; then
         print_status "Warning user" $YELLOW
@@ -193,8 +196,9 @@ main() {
         get_mongo "$MONGO_VERSION"
     else
         get_bson
+        get_zmq "$ZMQ_VERSION"
     fi
-    
+
     build_routeflow $@
 }
 

--- a/dist/build_bson.sh
+++ b/dist/build_bson.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+MONGO_URL="http://downloads.mongodb.org/cxx-driver"
+TARBALL_BASE="mongodb-linux-x86_64-"
+EXPANDED_BASE="mongo-cxx-driver-nightly"
+API="api-mongo"
+BSON_VESION="2.5.0"
+
+prune_non_apache() {
+    find $1 -type f | xargs grep -L 'Apache License' | xargs rm -rf 
+}
+
+##
+# Fetch BSON C++ sources from MongoDB's C++ Driver
+#
+# $1 - Version string, defaults to "latest"
+##
+get_bson_cxx() {
+    VER=${1-$BSON_VESION}
+    ORIG_SRC="$TARBALL_BASE$VER.tgz"
+    PATCH="${RFDIR}/dist/mongo-bson-$VER.patch"
+
+    if [ \! -e "$ORIG_SRC" ] || [ $UPDATE -eq 1 ]; then
+        if [ -n "$(which wget)" ]; then
+            $DO wget "$MONGO_URL/$ORIG_SRC" || fail "couldn't wget $ORIG_SRC"
+        elif [ -n "$(which curl)" ]; then
+            $DO curl -O "$MONGO_URL/$ORIG_SRC" || fail "couldn't curl $ORIG_SRC"
+        else
+            fail "need wget or curl installed to fetch $ORIG_SRC"
+        fi
+
+        $DO rm -rf $EXPANDED_BASE $API
+    fi
+
+    if [ \! -e "$API" ]; then
+        $DO tar xzf $ORIG_SRC
+        $DO prune_non_apache $EXPANDED_BASE
+        $DO mv $EXPANDED_BASE/src/mongo api-mongo
+        $DO rm -rf $EXPANDED_BASE
+        if [ -e "$PATCH" ]; then
+            print_status "Patching BSON"
+            $DO patch -p1 -i ${PATCH} || fail "Couldn't apply BSON patch"
+        else
+            fail "missing required BSON patching file $PATCH"
+        fi
+    fi
+}
+
+get_bson() {
+    get_bson_cxx $1
+}

--- a/dist/build_zmq.sh
+++ b/dist/build_zmq.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+ZMQ_URL="http://download.zeromq.org/"
+ZMQ_GIT="git@github.com:zeromq/libzmq.git"
+ZMQ_BRANCH="master"
+
+##
+# Fetch and build MongoDB from source.
+#
+# $1 - Version string or "git"
+##
+build_zmq() {
+    if [ -e "mongodb-src-r$1" ] && [ $UPDATE -eq 0 ]; then
+        return;
+    fi
+
+    fetch "zeromq-" $1 $ZMQ_GIT $ZMQ_BRANCH $ZMQ_URL ||
+        fail "Couldn't fetch MongoDB"
+
+    $DO ./configure || fail "Couldn't configure ZeroMQ"
+    $DO make || fail "Couldn't build ZeroMQ"
+    $SUPER make install || fail "Couldn't install ZeroMQ"
+    $SUPER ldconfig
+    $DO cd ..
+
+    $SUPER pip install pyzmq==13.1.0
+}
+
+get_zmq() {
+    build_zmq $@
+}

--- a/dist/mongo-bson-2.5.0.patch
+++ b/dist/mongo-bson-2.5.0.patch
@@ -1,0 +1,130 @@
+diff --git a/api-mongo/bson/bsonobj.h b/api-mongo/bson/bsonobj.h
+--- a/api-mongo/bson/bsonobj.h
++++ b/api-mongo/bson/bsonobj.h
+@@ -28,7 +28,9 @@
+ #include "mongo/base/string_data.h"
+ #include "mongo/bson/util/atomic_int.h"
+ #include "mongo/bson/util/builder.h"
++#if 0 // Not Apache licensed code
+ #include "mongo/util/bufreader.h"
++#endif
+ 
+ namespace mongo {
+ 
+@@ -499,6 +501,7 @@ namespace mongo {
+         return *this;
+     }
+ 
++#if 0 // Not needed, and relies on non-Apache licensed code for BufReader
+     /// members for Sorter
+     struct SorterDeserializeSettings {}; // unused
+     void serializeForSorter(BufBuilder& buf) const { buf.appendBuf(objdata(), objsize()); }
+@@ -511,6 +514,7 @@ namespace mongo {
+         // TODO consider ownedness?
+         return sizeof(BSONObj) + objsize();
+     }
++#endif
+ 
+     private:
+         const char *_objdata;
+diff --git a/api-mongo/bson/oid.cpp b/api-mongo/bson/oid.cpp
+--- a/api-mongo/bson/oid.cpp
++++ b/api-mongo/bson/oid.cpp
+@@ -15,6 +15,7 @@
+  *    limitations under the License.
+  */
+ 
++#if 0 // Not needed by BSON
+ #include "mongo/pch.h"
+ 
+ #include <boost/functional/hash.hpp>
+@@ -29,9 +30,14 @@
+ 
+ BOOST_STATIC_ASSERT( sizeof(mongo::OID) == mongo::OID::kOIDSize );
+ BOOST_STATIC_ASSERT( sizeof(mongo::OID) == 12 );
++#else
++#include "mongo/bson/bson.h"
++#include "mongo/bson/bsonobjbuilder.h"
++#endif
+ 
+ namespace mongo {
+ 
++#if 0 // Not needed by BSON
+     void OID::hash_combine(size_t &seed) const {
+         boost::hash_combine(seed, x);
+         boost::hash_combine(seed, y);
+@@ -180,6 +186,7 @@ namespace mongo {
+         T[3] = data[0];
+         return time;
+     }
++#endif
+ 
+     const string BSONObjBuilder::numStrs[] = {
+         "0",  "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9",
+diff --git a/api-mongo/db/jsobj.cpp b/api-mongo/db/jsobj.cpp
+--- a/api-mongo/db/jsobj.cpp
++++ b/api-mongo/db/jsobj.cpp
+@@ -16,10 +16,11 @@
+  *    See the License for the specific language governing permissions and
+  *    limitations under the License.
+  */
+-
++#if 0 // Not needed for BSON
+ #include "mongo/pch.h"
+ 
+ #include "mongo/db/jsobj.h"
++#endif
+ 
+ #include <limits>
+ #include <cmath>
+@@ -27,6 +28,7 @@
+ #include <boost/lexical_cast.hpp>
+ #include <boost/static_assert.hpp>
+ 
++#if 0 // Not needed for BSON
+ #include "mongo/bson/bson_validate.h"
+ #include "mongo/bson/oid.h"
+ #include "mongo/bson/util/atomic_int.h"
+@@ -40,6 +42,10 @@
+ #include "mongo/util/mongoutils/str.h"
+ #include "mongo/util/startup_test.h"
+ #include "mongo/util/stringutils.h"
++#else
++#include "mongo/bson/bson.h"
++#include "mongo/bson/bsonelement.h"
++#endif
+ 
+ // make sure our assumptions are valid
+ BOOST_STATIC_ASSERT( sizeof(short) == 2 );
+@@ -50,7 +56,7 @@ BOOST_STATIC_ASSERT( sizeof(mongo::Date_t) == 8 );
+ BOOST_STATIC_ASSERT( sizeof(mongo::OID) == 12 );
+ 
+ namespace mongo {
+-
++#if 0 // Not needed for BSON
+     BSONElement eooElement;
+ 
+     GENOIDLabeler GENOID;
+@@ -327,6 +333,7 @@ namespace mongo {
+         }
+         return def;
+     }
++#endif
+ 
+     /** transform a BSON array into a vector of BSONElements.
+         we match array # positions with their vector position, and ignore
+@@ -356,6 +363,7 @@ namespace mongo {
+     }
+ 
+ 
++#if 0 // Not needed for BSON
+ 
+     /* Matcher --------------------------------------*/
+ 
+@@ -1375,5 +1383,6 @@ namespace mongo {
+             default: return "Invalid";
+         }
+     }
++#endif
+ 
+ } // namespace mongo

--- a/pox/ext/rfproxy.py
+++ b/pox/ext/rfproxy.py
@@ -1,14 +1,11 @@
 import struct
 import logging
-import threading
-import time
 
 from pox.core import core
 from pox.openflow.libopenflow_01 import *
-import pymongo as mongo
 
 import rflib.ipc.IPC as IPC
-import rflib.ipc.MongoIPC as MongoIPC
+import rflib.ipc.IPCService as IPCService
 from rflib.ipc.RFProtocol import *
 from rflib.ipc.RFProtocolFactory import RFProtocolFactory
 from rflib.defs import *
@@ -64,8 +61,7 @@ netmask_prefix = lambda a: sum([bin(int(x)).count("1") for x in a.split(".", 4)]
 
 # TODO: add proper support for ID
 ID = 0
-ipc = MongoIPC.MongoIPCMessageService(MONGO_ADDRESS, MONGO_DB_NAME, str(ID),
-                                      threading.Thread, time.sleep)
+ipc = IPCService.for_proxy(str(ID))
 table = Table()
 
 # Logging

--- a/rfclient/RFClient.cc
+++ b/rfclient/RFClient.cc
@@ -8,8 +8,6 @@
 #include <boost/thread.hpp>
 
 #include "defs.h"
-#include "ipc/MongoIPC.h"
-#include "ipc/RFProtocol.h"
 #include "RFClient.hh"
 
 using namespace std;
@@ -84,7 +82,7 @@ RFClient::RFClient(uint64_t id, const string &address, RouteSource source) {
 
     string id_str = to_string<uint64_t>(id);
     syslog(LOG_INFO, "Starting RFClient (vm_id=%s)", id_str.c_str());
-    ipc = new MongoIPCMessageService(address, MONGO_DB_NAME, id_str);
+    ipc = IPCMessageServiceFactory::forClient(address, id_str);
 
     vector<Interface> ifaces = this->load_interfaces();
     vector<Interface>::iterator it;
@@ -273,11 +271,11 @@ void usage(char *name) {
 }
 
 int main(int argc, char* argv[]) {
-    char c;
-    uint64_t id = get_interface_id(DEFAULT_RFCLIENT_INTERFACE);
-    string address = MONGO_ADDRESS;
+    string address = "";  /* Empty means use default. */
     RouteSource route_source = RS_NETLINK;
+    uint64_t id = get_interface_id(DEFAULT_RFCLIENT_INTERFACE);
 
+    char c;
     while ((c = getopt (argc, argv, "a:fi:n:h")) != -1) {
         switch(c) {
         case 'a':

--- a/rflib/bson/Makefile
+++ b/rflib/bson/Makefile
@@ -1,0 +1,27 @@
+LIBDEP=1
+
+PLIB :=
+
+API_MONGO_DIR := ../../api-mongo
+API_MONGO_SOURCES := base/error_codes.cpp base/parse_number.cpp \
+	base/status.cpp bson/oid.cpp db/jsobj.cpp
+
+SOURCE_FILES := $(patsubst %.cpp,%.cc, $(notdir $(API_MONGO_SOURCES)))
+
+$(BUILD_OBJ_DIR)/$(notdir $(CURDIR))/error_codes.o: $(API_MONGO_DIR)/base/error_codes.cpp
+	$(CPP) $(CFLAGS) $(CPPFLAGS) -c  $< -o $@
+
+$(BUILD_OBJ_DIR)/$(notdir $(CURDIR))/parse_number.o: $(API_MONGO_DIR)/base/parse_number.cpp
+	$(CPP) $(CFLAGS) $(CPPFLAGS) -c  $< -o $@
+
+$(BUILD_OBJ_DIR)/$(notdir $(CURDIR))/status.o: $(API_MONGO_DIR)/base/status.cpp
+	$(CPP) $(CFLAGS) $(CPPFLAGS) -c  $< -o $@
+
+$(BUILD_OBJ_DIR)/$(notdir $(CURDIR))/oid.o: $(API_MONGO_DIR)/bson/oid.cpp
+	$(CPP) $(CFLAGS) $(CPPFLAGS) -c  $< -o $@
+
+$(BUILD_OBJ_DIR)/$(notdir $(CURDIR))/jsobj.o: $(API_MONGO_DIR)/db/jsobj.cpp
+	$(CPP) $(CFLAGS) $(CPPFLAGS) -c  $< -o $@
+
+
+include ../../Make.rules

--- a/rflib/defs.h
+++ b/rflib/defs.h
@@ -4,6 +4,8 @@
 #define MONGO_ADDRESS "192.168.10.1:27017"
 #define MONGO_DB_NAME "db"
 
+#define ZEROMQ_ADDRESS "tcp://192.168.10.1:25555"
+
 #define RFCLIENT_RFSERVER_CHANNEL "rfclient<->rfserver"
 #define RFSERVER_RFPROXY_CHANNEL "rfserver<->rfproxy"
 

--- a/rflib/defs.py
+++ b/rflib/defs.py
@@ -1,5 +1,11 @@
+
+IPC_TYPE = 'zeromq'  # options are 'zeromq' or 'mongo'
+DB_TYPE = 'mongo'   # options are 'memory' or 'mongo'
+
 MONGO_ADDRESS = "192.168.10.1:27017"
 MONGO_DB_NAME = "db"
+
+ZEROMQ_ADDRESS =  "tcp://192.168.10.1:25555"
 
 RFCLIENT_RFSERVER_CHANNEL = "rfclient<->rfserver"
 RFSERVER_RFPROXY_CHANNEL = "rfserver<->rfproxy"

--- a/rflib/defs.py
+++ b/rflib/defs.py
@@ -1,6 +1,6 @@
 
 IPC_TYPE = 'zeromq'  # options are 'zeromq' or 'mongo'
-DB_TYPE = 'mongo'   # options are 'memory' or 'mongo'
+DB_TYPE = 'memory'   # options are 'memory' or 'mongo'
 
 MONGO_ADDRESS = "192.168.10.1:27017"
 MONGO_DB_NAME = "db"

--- a/rflib/ipc/IPC.h
+++ b/rflib/ipc/IPC.h
@@ -90,4 +90,14 @@ class IPCMessageService {
         string id;
 };
 
+/** Factory for concrete instances of the IPC messaging service.
+*/
+class IPCMessageServiceFactory {
+    public:
+        /* These return a new service suitable for indicated situation. */
+
+        static IPCMessageService* forServer(const string& server, const string& id);
+        static IPCMessageService* forClient(const string& server, const string& id);
+        static IPCMessageService* forProxy(const string& server, const string& id);
+};
 #endif /* __IPC_H__ */

--- a/rflib/ipc/IPC.py
+++ b/rflib/ipc/IPC.py
@@ -1,36 +1,46 @@
-class IPCMessage:
+import bson
+
+class IPCMessage(object):
     def get_type(self):
         raise NotImplementedError
-    
-    def from_bson(self, data):
-        raise NotImplementedError
-        
-    def to_bson(self):
-        raise NotImplementedError
-        
-    def str(self):
+
+    def from_dict(self, data):
         raise NotImplementedError
 
-    def __str__(self):
-        return self.str()
+    def to_dict(self):
+        raise NotImplementedError
+
+    def from_bson(self, data):
+        return self.from_dict(bson.BSON(data).decode())
+
+    def to_bson(self):
+        return bson.BSON.encode(self.to_dict())
+
 
 class IPCMessageFactory:
     def build_for_type(self, type_):
         raise NotImplementedError
-        
+
 class IPCMessageProcessor:
     def process(self, from_, to, channel, msg):
         raise NotImplementedError
-        
+
 class IPCMessageService:
     def get_id(self):
         return self._id
-    
+
     def set_id(self, id_):
         self._id = id_
-        
+
     def listen(channel_id, factory, processor, block=True):
         raise NotImplementedError
-        
+
     def send(channel_id, to, msg):
         raise NotImplementedError
+
+
+class IPCRole(object):
+    server = 1
+    client = 2
+    proxy = 3
+

--- a/rflib/ipc/IPCService.py
+++ b/rflib/ipc/IPCService.py
@@ -1,0 +1,40 @@
+from rflib.defs import IPC_TYPE
+from IPC import IPCRole
+
+if IPC_TYPE == 'zeromq':
+    from ZeroMQIPC import buildIPC
+elif IPC_TYPE == 'mongo':
+    from MongoIPC import buildIPC
+else:
+    import sys
+    sys.exit("Unknown IPC_TYPE: {}".format(IPC_TYPE))
+
+"""
+In these functions, threading_ is an object with following properties:
+    Thread  - same api as threading.Thread,
+              created objects need to implement start() and join()
+    Event   - same api as threading.Event
+              created objects need to implement set() and wait()
+    sleep   - same api as time.sleep
+"""
+
+class StdThreading(object):
+    import threading
+    import time
+
+    Thread = staticmethod(threading.Thread)
+    Event = staticmethod(threading.Event)
+    sleep = staticmethod(time.sleep)
+    name = "StdThreading"
+
+
+def for_server(id_, threading_=StdThreading):
+    return buildIPC(IPCRole.server, id_, threading_)
+
+def for_client(id_, threading_=StdThreading):
+    return buildIPC(IPCRole.client, id_, threading_)
+
+def for_proxy(id_, threading_=StdThreading):
+    return buildIPC(IPCRole.proxy, id_, threading_)
+
+

--- a/rflib/ipc/Makefile
+++ b/rflib/ipc/Makefile
@@ -6,5 +6,11 @@ PLIB += -lmongoclient
 endif
 PLIB += -lboost_thread -lboost_filesystem -lboost_program_options
 
+SOURCE_FILES := IPC.cc RFProtocol.cc RFProtocolFactory.cc
+ifeq ($(IPC),zeromq)
+SOURCE_FILES += ZeroMQIPC.cc
+else ifeq ($(IPC),mongo)
+SOURCE_FILES += MongoIPC.cc
+endif
 
 include ../../Make.rules

--- a/rflib/ipc/Makefile
+++ b/rflib/ipc/Makefile
@@ -1,5 +1,10 @@
 LIBDEP=1
 
-PLIB := -lmongoclient -lboost_thread -lboost_filesystem -lboost_program_options
+PLIB :=
+ifneq (,$(USE_MONGO))
+PLIB += -lmongoclient
+endif
+PLIB += -lboost_thread -lboost_filesystem -lboost_program_options
+
 
 include ../../Make.rules

--- a/rflib/ipc/MongoIPC.cc
+++ b/rflib/ipc/MongoIPC.cc
@@ -1,10 +1,11 @@
 #include "MongoIPC.h"
 #include <boost/thread.hpp>
+#include "defs.h"
 
 MongoIPCMessageService::MongoIPCMessageService(const string &address, const string db, const string id) {
     this->set_id(id);
     this->db = db;
-    this->address = address;
+    this->address = address.size() > 0 ? address : MONGO_ADDRESS;
     this->connect(producerConnection, this->address);
 }
 
@@ -88,3 +89,15 @@ IPCMessage* takeFromEnvelope(mongo::BSONObj envelope, IPCMessageFactory *factory
    msg->from_BSON(envelope[CONTENT_FIELD].Obj().objdata());
    return msg;
 }
+
+
+IPCMessageService* IPCMessageServiceFactory::forServer(const string& server, const string& id) {
+    return new MongoIPCMessageService(server, MONGO_DB_NAME, id);
+}
+IPCMessageService* IPCMessageServiceFactory::forClient(const string& server, const string& id) {
+    return new MongoIPCMessageService(server, MONGO_DB_NAME, id);
+}
+IPCMessageService* IPCMessageServiceFactory::forProxy(const string& server, const string& id) {
+    return new MongoIPCMessageService(server, MONGO_DB_NAME, id);
+}
+

--- a/rflib/ipc/RFProtocol.cc
+++ b/rflib/ipc/RFProtocol.cc
@@ -1,6 +1,6 @@
 #include "RFProtocol.h"
 
-#include <mongo/client/dbclient.h>
+#include <mongo/bson/bson.h>
 
 PortRegister::PortRegister() {
     set_vm_id(0);

--- a/rflib/ipc/RFProtocol.py
+++ b/rflib/ipc/RFProtocol.py
@@ -1,10 +1,9 @@
 import bson
-import pymongo as mongo
 
 from rflib.types.Match import Match
 from rflib.types.Action import Action
 from rflib.types.Option import Option
-from MongoIPC import MongoIPCMessage
+from IPC import IPCMessage
 
 format_id = lambda dp_id: hex(dp_id).rstrip('L')
 
@@ -16,7 +15,7 @@ VIRTUAL_PLANE_MAP = 4
 DATA_PLANE_MAP = 5
 ROUTE_MOD = 6
 
-class PortRegister(MongoIPCMessage):
+class PortRegister(IPCMessage):
     def __init__(self, vm_id=None, vm_port=None, hwaddress=None):
         self.set_vm_id(vm_id)
         self.set_vm_port(vm_port)
@@ -67,13 +66,6 @@ class PortRegister(MongoIPCMessage):
         data["hwaddress"] = str(self.get_hwaddress())
         return data
 
-    def from_bson(self, data):
-        data = bson.BSON.decode(data)
-        self.from_dict(data)
-
-    def to_bson(self):
-        return bson.BSON.encode(self.get_dict())
-
     def __str__(self):
         s = "PortRegister\n"
         s += "  vm_id: " + format_id(self.get_vm_id()) + "\n"
@@ -81,7 +73,7 @@ class PortRegister(MongoIPCMessage):
         s += "  hwaddress: " + str(self.get_hwaddress()) + "\n"
         return s
 
-class PortConfig(MongoIPCMessage):
+class PortConfig(IPCMessage):
     def __init__(self, vm_id=None, vm_port=None, operation_id=None):
         self.set_vm_id(vm_id)
         self.set_vm_port(vm_port)
@@ -132,13 +124,6 @@ class PortConfig(MongoIPCMessage):
         data["operation_id"] = str(self.get_operation_id())
         return data
 
-    def from_bson(self, data):
-        data = bson.BSON.decode(data)
-        self.from_dict(data)
-
-    def to_bson(self):
-        return bson.BSON.encode(self.get_dict())
-
     def __str__(self):
         s = "PortConfig\n"
         s += "  vm_id: " + format_id(self.get_vm_id()) + "\n"
@@ -146,7 +131,7 @@ class PortConfig(MongoIPCMessage):
         s += "  operation_id: " + str(self.get_operation_id()) + "\n"
         return s
 
-class DatapathPortRegister(MongoIPCMessage):
+class DatapathPortRegister(IPCMessage):
     def __init__(self, ct_id=None, dp_id=None, dp_port=None):
         self.set_ct_id(ct_id)
         self.set_dp_id(dp_id)
@@ -197,13 +182,6 @@ class DatapathPortRegister(MongoIPCMessage):
         data["dp_port"] = str(self.get_dp_port())
         return data
 
-    def from_bson(self, data):
-        data = bson.BSON.decode(data)
-        self.from_dict(data)
-
-    def to_bson(self):
-        return bson.BSON.encode(self.get_dict())
-
     def __str__(self):
         s = "DatapathPortRegister\n"
         s += "  ct_id: " + format_id(self.get_ct_id()) + "\n"
@@ -211,7 +189,7 @@ class DatapathPortRegister(MongoIPCMessage):
         s += "  dp_port: " + str(self.get_dp_port()) + "\n"
         return s
 
-class DatapathDown(MongoIPCMessage):
+class DatapathDown(IPCMessage):
     def __init__(self, ct_id=None, dp_id=None):
         self.set_ct_id(ct_id)
         self.set_dp_id(dp_id)
@@ -249,20 +227,13 @@ class DatapathDown(MongoIPCMessage):
         data["dp_id"] = str(self.get_dp_id())
         return data
 
-    def from_bson(self, data):
-        data = bson.BSON.decode(data)
-        self.from_dict(data)
-
-    def to_bson(self):
-        return bson.BSON.encode(self.get_dict())
-
     def __str__(self):
         s = "DatapathDown\n"
         s += "  ct_id: " + format_id(self.get_ct_id()) + "\n"
         s += "  dp_id: " + format_id(self.get_dp_id()) + "\n"
         return s
 
-class VirtualPlaneMap(MongoIPCMessage):
+class VirtualPlaneMap(IPCMessage):
     def __init__(self, vm_id=None, vm_port=None, vs_id=None, vs_port=None):
         self.set_vm_id(vm_id)
         self.set_vm_port(vm_port)
@@ -326,13 +297,6 @@ class VirtualPlaneMap(MongoIPCMessage):
         data["vs_port"] = str(self.get_vs_port())
         return data
 
-    def from_bson(self, data):
-        data = bson.BSON.decode(data)
-        self.from_dict(data)
-
-    def to_bson(self):
-        return bson.BSON.encode(self.get_dict())
-
     def __str__(self):
         s = "VirtualPlaneMap\n"
         s += "  vm_id: " + format_id(self.get_vm_id()) + "\n"
@@ -341,7 +305,7 @@ class VirtualPlaneMap(MongoIPCMessage):
         s += "  vs_port: " + str(self.get_vs_port()) + "\n"
         return s
 
-class DataPlaneMap(MongoIPCMessage):
+class DataPlaneMap(IPCMessage):
     def __init__(self, ct_id=None, dp_id=None, dp_port=None, vs_id=None, vs_port=None):
         self.set_ct_id(ct_id)
         self.set_dp_id(dp_id)
@@ -418,13 +382,6 @@ class DataPlaneMap(MongoIPCMessage):
         data["vs_port"] = str(self.get_vs_port())
         return data
 
-    def from_bson(self, data):
-        data = bson.BSON.decode(data)
-        self.from_dict(data)
-
-    def to_bson(self):
-        return bson.BSON.encode(self.get_dict())
-
     def __str__(self):
         s = "DataPlaneMap\n"
         s += "  ct_id: " + format_id(self.get_ct_id()) + "\n"
@@ -434,7 +391,7 @@ class DataPlaneMap(MongoIPCMessage):
         s += "  vs_port: " + str(self.get_vs_port()) + "\n"
         return s
 
-class RouteMod(MongoIPCMessage):
+class RouteMod(IPCMessage):
     def __init__(self, mod=None, id=None, matches=None, actions=None, options=None):
         self.set_mod(mod)
         self.set_id(id)
@@ -519,13 +476,6 @@ class RouteMod(MongoIPCMessage):
         data["actions"] = self.get_actions()
         data["options"] = self.get_options()
         return data
-
-    def from_bson(self, data):
-        data = bson.BSON.decode(data)
-        self.from_dict(data)
-
-    def to_bson(self):
-        return bson.BSON.encode(self.get_dict())
 
     def __str__(self):
         s = "RouteMod\n"

--- a/rflib/ipc/ZeroMQIPC.cc
+++ b/rflib/ipc/ZeroMQIPC.cc
@@ -1,0 +1,320 @@
+#include "ZeroMQIPC.h"
+
+#include <iostream>
+
+#include <boost/lambda/bind.hpp>
+#include <mongo/bson/bson.h>
+
+#include "defs.h"
+
+#define INTERNAL_SEND_CHANNEL "inproc://sender"
+#define INTERNAL_PUBLISH_CHANNEL "inproc://channeler"
+
+#ifndef DEBUG
+#define DEBUG false
+#endif
+
+static void messageString(zmq::message_t &msg, const string &str) {
+    size_t len = str.size();
+    msg.rebuild(len);
+    memcpy(msg.data(), str.data(), len);
+}
+
+static void noteZmqError(const zmq::error_t &err) {
+    std::cerr << "ZMQ error: " << err.what() << std::endl << std::flush;
+}
+
+template <class T>
+static void noteZmqError(T prefix, const zmq::error_t &err) {
+    std::cerr << '[' << prefix << "] ";
+    noteZmqError(err);
+}
+
+template <class T1, class T2>
+static void noteZmqError(T1 p1, T2 p2, const zmq::error_t &err) {
+    std::cerr << '[' << p1 << ' ' << p2 << "] ";
+    noteZmqError(err);
+}
+
+/** This worker manages the external socket. It proxies messages to send out
+the external socket, and external messages are proxied into the internal pub-sub
+system. We need to do this extra layer because each socket in ZMQ must be
+created and managed by exactly one thread. Since the usage model of IPC is that
+the main thread sends messages, but listening threads handle incoming messages,
+the actual external socket must be managed by yet its own thread. */
+void ZeroMQIPCMessageService::mainWorker(
+        const string &serverAddress, bool bind) {
+    zmq::socket_t external(*ctx, ZMQ_ROUTER);
+    external.setsockopt(ZMQ_IDENTITY, id.data(), id.length());
+
+    if (bind) {
+        try {
+            external.bind(serverAddress.c_str());
+        } catch (const zmq::error_t &err) {
+            noteZmqError("mainWorker external.bind", serverAddress, err);
+            exit(1);
+        }
+    } else {
+        try {
+            const int one = 1;
+            external.connect(serverAddress.c_str());
+            external.setsockopt(ZMQ_ROUTER_MANDATORY, &one, sizeof(one));
+        } catch (const zmq::error_t &err) {
+            noteZmqError("mainWorker external.connect", serverAddress, err);
+            exit(1);
+        }
+    }
+
+    /* The mailbox will receive messages to send to the external socket. */
+    zmq::socket_t mailbox(*ctx, ZMQ_PAIR);
+    try {
+        mailbox.connect(INTERNAL_SEND_CHANNEL);
+    } catch (const zmq::error_t &err) {
+        noteZmqError("mainWorker mailbox.connect", INTERNAL_SEND_CHANNEL, err);
+    }
+
+    /* The publisher will publish messages received from the external socket */
+    zmq::socket_t publisher(*ctx, ZMQ_PUB);
+    try {
+        publisher.bind(INTERNAL_PUBLISH_CHANNEL);
+    } catch (const zmq::error_t &err) {
+        noteZmqError("mainWorker publisher.bind", INTERNAL_PUBLISH_CHANNEL, err);
+    }
+
+    ready.unlock();
+
+    /* Now, poll both external and sender, and forward messages */
+    zmq::pollitem_t items[] = {
+        { external, 0, ZMQ_POLLIN, 0 },
+        { mailbox, 0, ZMQ_POLLIN, 0 }
+    };
+
+    while (true) {
+        try {
+            zmq::poll(items, sizeof(items)/sizeof(items[0]), -1);
+
+            if (items[0].revents & ZMQ_POLLIN) {
+                // copy message from external to publisher... however:
+                // message frames are:              <addr>,<channel>,<type>,<message>
+                // these need to be re-shuffled to: <channel>,<addr>,<type>,<message>
+                // This is so that the PUB?SUB mechanism can select on the channel.
+                zmq::message_t addrFrame;
+                zmq::message_t channelFrame;
+
+                external.recv(&addrFrame);
+                if (!addrFrame.more()) continue;
+
+                external.recv(&channelFrame);
+                bool more = channelFrame.more();
+
+                publisher.send(channelFrame, ZMQ_SNDMORE);
+                publisher.send(addrFrame, more ? ZMQ_SNDMORE : 0);
+
+                while (more) {
+                    zmq::message_t dataFrame;
+                    external.recv(&dataFrame);
+                    more = dataFrame.more();
+                    publisher.send(dataFrame, more ? ZMQ_SNDMORE : 0);
+                }
+            }
+
+            if (items[1].revents & ZMQ_POLLIN) {
+                // copy message from mailbox to external.
+                zmq::message_t address;
+                zmq::message_t channel;
+                zmq::message_t type;
+                zmq::message_t payload;
+
+                do {
+                    mailbox.recv(&address);     if (!address.more()) break;
+                    mailbox.recv(&channel);     if (!channel.more()) break;
+                    mailbox.recv(&type);        if (!type.more()) break;
+                    mailbox.recv(&payload);
+                    if (payload.more()) {
+                        for (bool more = true; more;) {
+                            zmq::message_t extra;
+                            mailbox.recv(&extra);
+                            more = extra.more();
+                        }
+                        break;
+                    }
+
+                    bool retry = false;
+                    for (int attempt = bind ? 1 : 30; attempt > 0; --attempt) {
+                        try {
+                            external.send(address, ZMQ_SNDMORE);
+                            external.send(channel, ZMQ_SNDMORE);
+                            external.send(type, ZMQ_SNDMORE);
+                            external.send(payload);
+                            if (retry) {
+                                std::cerr << "[ZMQIPC mainWorker external.forward] succeeded" << std::endl;
+                            }
+                            break;
+                        } catch (const zmq::error_t &err) {
+                            noteZmqError("mainWorker external.forward", err);
+                            if (attempt > 1 && err.num() == EHOSTUNREACH) {
+                                std::cerr << "[ZMQIPC mainWorker external.forward], sleeping" << std::endl;
+                                usleep(500*1000);
+                                retry = true;
+                            } else {
+                                std::cerr << "[ZMQIPC mainWorker external.forward], gave up" << std::endl;
+                                break;
+                            }
+                        }
+                    }
+                } while (false);
+            }
+        } catch (const zmq::error_t &err) {
+            noteZmqError("mainWorker", err);
+            throw;
+        }
+    }
+}
+
+/** This worker subscribes to a given channel, and builds and processes messages
+that it receives. */
+void ZeroMQIPCMessageService::subWorker(const string &channelId,
+        IPCMessageFactory *factory, IPCMessageProcessor *processor) {
+
+    {
+        // ensure the mainWorker is ready before proceeding
+        boost::lock_guard<boost::mutex> lock(ready);
+    }
+
+    zmq::socket_t subscriber(*ctx, ZMQ_SUB);
+    try {
+
+        subscriber.setsockopt(ZMQ_SUBSCRIBE, channelId.data(), channelId.length());
+        subscriber.connect(INTERNAL_PUBLISH_CHANNEL);
+    } catch (const zmq::error_t &err) {
+        noteZmqError("subWorker subscriber.connect", INTERNAL_PUBLISH_CHANNEL, err);
+        exit(2);
+    }
+
+    while (true) {
+        try {
+            zmq::message_t channel;
+            zmq::message_t addr;
+            zmq::message_t type;
+            zmq::message_t payload;
+
+            subscriber.recv(&channel);
+            if (!channel.more()) continue;
+
+            subscriber.recv(&addr);
+            if (!addr.more()) continue;
+
+            subscriber.recv(&type);
+            if (!type.more()) continue;
+
+            subscriber.recv(&payload);
+            bool more = payload.more();
+
+            while (more) {
+                zmq::message_t extra;
+                subscriber.recv(&extra);
+                more = extra.more();
+            }
+
+            if (type.size() == 1) {
+                IPCMessage *msg = factory->buildForType(static_cast<const char*>(type.data())[0]);
+                msg->from_BSON(static_cast<const char*>(payload.data()));
+
+                if (DEBUG) {
+                    std::string ch(static_cast<const char*>(channel.data()), channel.size());
+                    std::string from(static_cast<const char*>(addr.data()), addr.size());
+
+                    std::cerr << "[ZMQIPC subWorker subscribe.recv] " << id
+                        << " ch " << ch << " from " << from
+                        << std::endl << msg->str();
+                }
+
+                processor->process(static_cast<const char*>(addr.data()), channelId, static_cast<const char*>(channel.data()), *msg);
+                delete msg;
+            }
+        } catch (const zmq::error_t &err) {
+            noteZmqError("subWorker", err);
+        }
+    }
+}
+
+
+ZeroMQIPCMessageService::ZeroMQIPCMessageService(
+        const string& serverAddress, const string _id, bool bind) : id(_id) {
+    string address = serverAddress.size() > 0 ? serverAddress : ZEROMQ_ADDRESS;
+
+    ready.lock();
+
+    ctx = new zmq::context_t(1);
+
+    try {
+        // the first socket of a pair must be bound first, and since the other end
+        // is in a thread, we don't know when that will actually get created.
+        this->sender = new zmq::socket_t(*this->ctx, ZMQ_PAIR);
+        this->sender->bind(INTERNAL_SEND_CHANNEL);
+    } catch (const zmq::error_t &err) {
+        noteZmqError("ZeroMQIPCMessageService::ctor sender.bind", INTERNAL_SEND_CHANNEL, err);
+        exit(3);
+    }
+
+    boost::thread t(boost::bind(&ZeroMQIPCMessageService::mainWorker, this,
+                                address, bind));
+    t.detach();
+}
+
+
+void ZeroMQIPCMessageService::listen(const string &channelId, IPCMessageFactory *factory, IPCMessageProcessor *processor, bool block) {
+    boost::thread t(boost::bind(&ZeroMQIPCMessageService::subWorker, this,
+                                channelId, factory, processor));
+    if (block)
+        t.join();
+    else
+        t.detach();
+}
+
+bool ZeroMQIPCMessageService::send(const string &channelId, const string &to, IPCMessage& msg) {
+    try {
+        if (DEBUG) {
+            std::cerr << "[ZMQIPC send] " << id
+                << "ch " << channelId << " to " << to
+                << std::endl << msg.str();
+        }
+
+        zmq::message_t destination;
+        messageString(destination, to);
+
+        zmq::message_t channel;
+        messageString(channel, channelId);
+
+        zmq::message_t type(1);
+        static_cast<char *>(type.data())[0] = (char)msg.get_type();
+
+        const char* msgBSONBytes = msg.to_BSON();
+        size_t msgBSONSize = mongo::BSONObj(msgBSONBytes).objsize();
+        zmq::message_t payload(msgBSONSize);
+        memcpy(payload.data(), msgBSONBytes, msgBSONSize);
+        delete msgBSONBytes;
+
+        this->sender->send(destination, ZMQ_SNDMORE);
+        this->sender->send(channel, ZMQ_SNDMORE);
+        this->sender->send(type, ZMQ_SNDMORE);
+        this->sender->send(payload);
+    } catch (const zmq::error_t &err) {
+        noteZmqError("send", err);
+        return false;
+    }
+
+    return true;
+}
+
+
+IPCMessageService* IPCMessageServiceFactory::forServer(const string& server, const string& id) {
+    return new ZeroMQIPCMessageService(server, id, true);
+}
+IPCMessageService* IPCMessageServiceFactory::forClient(const string& server, const string& id) {
+    return new ZeroMQIPCMessageService(server, id, false);
+}
+IPCMessageService* IPCMessageServiceFactory::forProxy(const string& server, const string& id) {
+    return new ZeroMQIPCMessageService(server, id, false);
+}
+

--- a/rflib/ipc/ZeroMQIPC.h
+++ b/rflib/ipc/ZeroMQIPC.h
@@ -1,0 +1,30 @@
+#ifndef __ZEORMQIPC_H__
+#define __ZEROMQIPC_H__
+
+#include <boost/thread.hpp>
+#include <string>
+#include <zmq.hpp>
+
+#include "IPC.h"
+
+/** An IPC message service that uses ZeroIPC as the backend. */
+class ZeroMQIPCMessageService : public IPCMessageService {
+    public:
+        ZeroMQIPCMessageService(const string&serverAddress, const string id, bool bind);
+
+        virtual void listen(const string &channelId, IPCMessageFactory *factory, IPCMessageProcessor *processor, bool block=true);
+        virtual bool send(const string &channelId, const string &to, IPCMessage& msg);
+
+    private:
+        std::string id;
+        zmq::context_t* ctx;
+        zmq::socket_t* sender;
+        boost::mutex ready;
+
+        void mainWorker(const string &serverAddress, bool bind);
+        void subWorker(const string &channelId,
+            IPCMessageFactory *factory, IPCMessageProcessor *processor);
+};
+
+
+#endif /* __ZEROMQIPC_H__ */

--- a/rflib/ipc/ZeroMQIPC.py
+++ b/rflib/ipc/ZeroMQIPC.py
@@ -1,0 +1,164 @@
+import logging
+import struct
+import sys
+
+if 'eventlet' in sys.modules:
+    from eventlet.green import zmq
+    __using_eventlet__ = True
+else:
+    import zmq
+    __using_eventlet__ = False
+
+from rflib.defs import *
+import rflib.ipc.IPC as IPC
+
+INTERNAL_SEND_CHANNEL = "inproc://sender"
+INTERNAL_PUBLISH_CHANNEL = "inproc://channeler"
+
+_logger = logging.getLogger(__name__)
+_logger.setLevel(logging.DEBUG)
+
+class ZeroMQIPCMessageService(IPC.IPCMessageService):
+    def __init__(self, address, id_, threading_, bind):
+        self._id = id_
+        self._threading = threading_
+        self._ctx = zmq.Context(1)
+        self._sender = self._ctx.socket(zmq.PAIR)
+        self._sender.bind(INTERNAL_SEND_CHANNEL)
+
+        self._ready = self._threading.Event()
+
+        worker = self._threading.Thread(target=self._main_worker,
+                                        args=(address, bind),
+                                        name="ipc-main-worker")
+        worker.start()
+
+    def listen(self, channel_id, factory, processor, block=True):
+        self._ready.wait()
+        worker = self._threading.Thread(target=self._sub_worker,
+                                        args=(channel_id, factory, processor),
+                                        name=("ipc-channel-" + channel_id + "-worker"))
+        worker.start()
+        if block:
+            worker.join()
+
+    def send(self, channel_id, to, msg):
+        _logger.debug('send on ch %s to %s:\n%s', channel_id, to, str(msg))
+        self._sender.send(to, zmq.SNDMORE)
+        self._sender.send(channel_id, zmq.SNDMORE)
+        self._sender.send(struct.pack('B', msg.get_type()), zmq.SNDMORE)
+        self._sender.send(msg.to_bson())
+        return True
+
+    def _main_worker(self, address, bind):
+        external = self._ctx.socket(zmq.ROUTER)
+        external.identity = self._id
+
+        if bind:
+            external.bind(address)
+        else:
+            external.connect(address)
+            external.router_behavior = 1    # ZMQ_ROUTER_MANDATORY, but pyzmq
+                                            # doesn't have newer option name
+
+        # The mailbox will receive messages to send to the external socket.
+        mailbox = self._ctx.socket(zmq.PAIR)
+        mailbox.connect(INTERNAL_SEND_CHANNEL)
+
+        # The publisher will publish messages received from the external socket
+        publisher = self._ctx.socket(zmq.PUB)
+        publisher.bind(INTERNAL_PUBLISH_CHANNEL)
+
+        def handle_external():
+            # Copy message from external to publisher... however:
+            # message frames are:              <addr>,<channel>,<type>,<msg>
+            # these need to be re-shuffled to: <channel>,<addr>,<type>,<msg>
+            # This is so that the PUB/SUB mechanism can match the channel.
+            parts = external.recv_multipart(copy=False)
+            if len(parts) >= 2:
+                parts[0], parts[1] = parts[1], parts[0]
+                publisher.send_multipart(parts, copy=False)
+
+        def handle_mailbox():
+            # Copy messages from mailbox to external. Retry if sending fails,
+            # as the external socket may take time to connect.
+            parts = mailbox.recv_multipart(copy=False)
+            retry = False
+            for attempt in xrange(1 if bind else 30, 0, -1):
+                try:
+                    external.send_multipart(parts, copy=False)
+                    if retry:
+                        _logger.warning("external send succeeded")
+                    break
+                except zmq.ZMQError as e:
+                    if e.errno == zmq.EHOSTUNREACH:
+                        if attempt > 1:
+                            _logger.warning("external send failed, sleeping")
+                            self._threading.sleep(0.5)
+                            retry = True
+                        else:
+                            _logger.error("external send failed, gave up")
+                            pass # dropped unroutable message
+                    else:
+                        raise
+
+        def loop_external():
+            while True:
+                handle_external()
+
+        def loop_mailbox():
+            while True:
+                handle_mailbox()
+
+        self._ready.set()
+
+        if __using_eventlet__:
+            # Since all eventlet threads are in the same OS thread, this code
+            # can read from external in one eventlet thread, and write to
+            # external in another. Furthermore, zmq.Poller isn't supported in
+            # eventlet, so this is the easiest way.
+            self._threading.Thread(target=loop_external,
+                                   name="ipc-main-external").start()
+            self._threading.Thread(target=loop_mailbox,
+                                   name="ipc-main-mailbox").start()
+        else:
+            # Since we must read and write external from the same OS thread (a
+            # ZMQ constraint), and we read mailbox to write external, this code,
+            # running in a single OS thread, uses zmq.Poller to poll both
+            # external and mailbox for incoming messages.
+            poller = zmq.Poller()
+            poller.register(external, zmq.POLLIN)
+            poller.register(mailbox, zmq.POLLIN)
+
+            while True:
+                ready = dict(poller.poll())
+
+                if external in ready and ready[external] == zmq.POLLIN:
+                    handle_external()
+
+                if mailbox in ready and ready[mailbox] == zmq.POLLIN:
+                    handle_mailbox()
+
+
+
+    def _sub_worker(self, channel_id, factory, processor):
+        subscriber = self._ctx.socket(zmq.SUB)
+        subscriber.subscribe = channel_id
+        subscriber.connect(INTERNAL_PUBLISH_CHANNEL)
+        _logger.debug('subscribing to ch %s', channel_id)
+
+        while True:
+            parts = subscriber.recv_multipart()
+            if len(parts) != 4:
+                continue
+
+            (channel, addr, type_, payload) = parts
+            msg = factory.build_for_type(struct.unpack('B', type_)[0])
+            msg.from_bson(payload)
+            _logger.debug('receive on ch %s from %s:\n%s', channel, addr, str(msg))
+            processor.process(addr, self._id, channel, msg)
+
+
+def buildIPC(role, id_, threading_):
+    return ZeroMQIPCMessageService(ZEROMQ_ADDRESS, id_,
+                                   threading_, role == IPC.IPCRole.server)

--- a/rflib/ipc/msgen.py
+++ b/rflib/ipc/msgen.py
@@ -359,11 +359,10 @@ def genPy(messages, fname):
     g = CodeGenerator()
 
     g.addLine("import bson")    
-    g.addLine("import pymongo as mongo")
     g.blankLine()
     for tlv in ["Match","Action","Option"]:
         g.addLine("from rflib.types.{0} import {0}".format(tlv))
-    g.addLine("from MongoIPC import MongoIPCMessage")
+    g.addLine("from IPC import IPCMessage")
     g.blankLine()
     g.addLine("format_id = lambda dp_id: hex(dp_id).rstrip('L')")
     g.blankLine()
@@ -374,7 +373,7 @@ def genPy(messages, fname):
         v += 1
     g.blankLine()
     for name, msg in messages:
-        g.addLine("class {0}(MongoIPCMessage):".format(name))
+        g.addLine("class {0}(IPCMessage):".format(name))
         g.increaseIndent()
         g.addLine("def __init__(self, {0}):".format(", ".join([f + "=None" for t, f in msg])))
         g.increaseIndent()
@@ -435,19 +434,6 @@ def genPy(messages, fname):
         g.decreaseIndent()
         g.blankLine();
         
-        g.addLine("def from_bson(self, data):")
-        g.increaseIndent()
-        g.addLine("data = bson.BSON.decode(data)")
-        g.addLine("self.from_dict(data)")
-        g.decreaseIndent()
-        g.blankLine()
-        
-        g.addLine("def to_bson(self):")
-        g.increaseIndent()
-        g.addLine("return bson.BSON.encode(self.get_dict())")
-        g.decreaseIndent()
-        g.blankLine()
-                
         g.addLine("def __str__(self):")
         g.increaseIndent();
         g.addLine("s = \"{0}\\n\"".format(name))

--- a/rflib/ipc/msgen.py
+++ b/rflib/ipc/msgen.py
@@ -210,7 +210,7 @@ def genCPP(messages, fname):
     
     g.addLine("#include \"{0}.h\"".format(fname))
     g.blankLine()
-    g.addLine("#include <mongo/client/dbclient.h>")
+    g.addLine("#include <mongo/bson/bson.h>")
     g.blankLine()
     for name, msg in messages:
         g.addLine("{0}::{0}() {{".format(name))

--- a/rflib/ipc/zmq.hpp
+++ b/rflib/ipc/zmq.hpp
@@ -1,0 +1,566 @@
+/*
+    Copyright (c) 2009-2011 250bpm s.r.o.
+    Copyright (c) 2011 Botond Ballo
+    Copyright (c) 2007-2009 iMatix Corporation
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+*/
+
+#ifndef __ZMQ_HPP_INCLUDED__
+#define __ZMQ_HPP_INCLUDED__
+
+#include <zmq.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <string>
+#include <exception>
+
+//  Detect whether the compiler supports C++11 rvalue references.
+#if (defined(__GNUC__) && (__GNUC__ > 4 || \
+      (__GNUC__ == 4 && __GNUC_MINOR__ > 2)) && \
+      defined(__GXX_EXPERIMENTAL_CXX0X__))
+    #define ZMQ_HAS_RVALUE_REFS
+    #define ZMQ_DELETED_FUNCTION = delete
+#elif defined(__clang__)
+    #if __has_feature(cxx_rvalue_references)
+        #define ZMQ_HAS_RVALUE_REFS
+    #endif
+
+    #if __has_feature(cxx_deleted_functions)
+        #define ZMQ_DELETED_FUNCTION = delete
+    #else
+        #define ZMQ_DELETED_FUNCTION
+    #endif
+#elif defined(_MSC_VER) && (_MSC_VER >= 1600)
+    #define ZMQ_HAS_RVALUE_REFS
+    #define ZMQ_DELETED_FUNCTION
+#else
+    #define ZMQ_DELETED_FUNCTION
+#endif
+
+#if ZMQ_VERSION >= ZMQ_MAKE_VERSION(3, 3, 0)
+#define ZMQ_NEW_MONITOR_EVENT_LAYOUT
+#endif
+
+// In order to prevent unused variable warnings when building in non-debug
+// mode use this macro to make assertions.
+#ifndef NDEBUG
+#   define ZMQ_ASSERT(expression) assert(expression)
+#else
+#   define ZMQ_ASSERT(expression) (void)(expression)
+#endif
+
+namespace zmq
+{
+
+    typedef zmq_free_fn free_fn;
+    typedef zmq_pollitem_t pollitem_t;
+
+    class error_t : public std::exception
+    {
+    public:
+
+        error_t () : errnum (zmq_errno ()) {}
+
+        virtual const char *what () const throw ()
+        {
+            return zmq_strerror (errnum);
+        }
+
+        int num () const
+        {
+            return errnum;
+        }
+
+    private:
+
+        int errnum;
+    };
+
+    inline int poll (zmq_pollitem_t *items_, int nitems_, long timeout_ = -1)
+    {
+        int rc = zmq_poll (items_, nitems_, timeout_);
+        if (rc < 0)
+            throw error_t ();
+        return rc;
+    }
+
+    inline void proxy (void *frontend, void *backend, void *capture)
+    {
+        int rc = zmq_proxy (frontend, backend, capture);
+        if (rc != 0)
+            throw error_t ();
+    }
+
+    inline void version (int *major_, int *minor_, int *patch_)
+    {
+        zmq_version (major_, minor_, patch_);
+    }
+
+    class message_t
+    {
+        friend class socket_t;
+
+    public:
+
+        inline message_t ()
+        {
+            int rc = zmq_msg_init (&msg);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline explicit message_t (size_t size_)
+        {
+            int rc = zmq_msg_init_size (&msg, size_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline message_t (void *data_, size_t size_, free_fn *ffn_,
+            void *hint_ = NULL)
+        {
+            int rc = zmq_msg_init_data (&msg, data_, size_, ffn_, hint_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+#ifdef ZMQ_HAS_RVALUE_REFS
+        inline message_t (message_t &&rhs) : msg (rhs.msg)
+        {
+            int rc = zmq_msg_init (&rhs.msg);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline message_t &operator = (message_t &&rhs)
+        {
+            std::swap (msg, rhs.msg);
+            return *this;
+        }
+#endif
+
+        inline ~message_t ()
+        {
+            int rc = zmq_msg_close (&msg);
+            ZMQ_ASSERT (rc == 0);
+        }
+
+        inline void rebuild ()
+        {
+            int rc = zmq_msg_close (&msg);
+            if (rc != 0)
+                throw error_t ();
+            rc = zmq_msg_init (&msg);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline void rebuild (size_t size_)
+        {
+            int rc = zmq_msg_close (&msg);
+            if (rc != 0)
+                throw error_t ();
+            rc = zmq_msg_init_size (&msg, size_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline void rebuild (void *data_, size_t size_, free_fn *ffn_,
+            void *hint_ = NULL)
+        {
+            int rc = zmq_msg_close (&msg);
+            if (rc != 0)
+                throw error_t ();
+            rc = zmq_msg_init_data (&msg, data_, size_, ffn_, hint_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline void move (message_t *msg_)
+        {
+            int rc = zmq_msg_move (&msg, &(msg_->msg));
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline void copy (message_t *msg_)
+        {
+            int rc = zmq_msg_copy (&msg, &(msg_->msg));
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline bool more ()
+        {
+            int rc = zmq_msg_more (&msg);
+            return rc != 0;
+        }
+
+        inline void *data ()
+        {
+            return zmq_msg_data (&msg);
+        }
+
+        inline const void* data () const
+        {
+            return zmq_msg_data (const_cast<zmq_msg_t*>(&msg));
+        }
+
+        inline size_t size () const
+        {
+            return zmq_msg_size (const_cast<zmq_msg_t*>(&msg));
+        }
+
+    private:
+
+        //  The underlying message
+        zmq_msg_t msg;
+
+        //  Disable implicit message copying, so that users won't use shared
+        //  messages (less efficient) without being aware of the fact.
+        message_t (const message_t&);
+        void operator = (const message_t&);
+    };
+
+    class context_t
+    {
+        friend class socket_t;
+
+    public:
+        inline context_t ()
+        {
+            ptr = zmq_ctx_new ();
+            if (ptr == NULL)
+                throw error_t ();
+        }
+
+
+        inline explicit context_t (int io_threads_)
+        {
+            ptr = zmq_ctx_new ();
+            if (ptr == NULL)
+                throw error_t ();
+
+            int rc = zmq_ctx_set (ptr, ZMQ_IO_THREADS, io_threads_);
+            ZMQ_ASSERT (rc == 0);
+        }
+
+#ifdef ZMQ_HAS_RVALUE_REFS
+        inline context_t (context_t &&rhs) : ptr (rhs.ptr)
+        {
+            rhs.ptr = NULL;
+        }
+        inline context_t &operator = (context_t &&rhs)
+        {
+            std::swap (ptr, rhs.ptr);
+            return *this;
+        }
+#endif
+
+        inline ~context_t ()
+        {
+            close();
+        }
+
+        inline void close()
+        {
+            if (ptr == NULL)
+                return;
+            int rc = zmq_ctx_destroy (ptr);
+            ZMQ_ASSERT (rc == 0);
+            ptr = NULL;
+        }
+
+        //  Be careful with this, it's probably only useful for
+        //  using the C api together with an existing C++ api.
+        //  Normally you should never need to use this.
+        inline operator void* ()
+        {
+            return ptr;
+        }
+
+    private:
+
+        void *ptr;
+
+        context_t (const context_t&);
+        void operator = (const context_t&);
+    };
+
+    class socket_t
+    {
+        friend class monitor_t;
+    public:
+
+        inline socket_t (context_t &context_, int type_)
+        {
+            ctxptr = context_.ptr;
+            ptr = zmq_socket (context_.ptr, type_);
+            if (ptr == NULL)
+                throw error_t ();
+        }
+
+#ifdef ZMQ_HAS_RVALUE_REFS
+        inline socket_t(socket_t&& rhs) : ptr(rhs.ptr)
+        {
+            rhs.ptr = NULL;
+        }
+        inline socket_t& operator=(socket_t&& rhs)
+        {
+            std::swap(ptr, rhs.ptr);
+            return *this;
+        }
+#endif
+
+        inline ~socket_t ()
+        {
+            close();
+        }
+
+        inline operator void* ()
+        {
+            return ptr;
+        }
+
+        inline void close()
+        {
+            if(ptr == NULL)
+                // already closed
+                return ;
+            int rc = zmq_close (ptr);
+            ZMQ_ASSERT (rc == 0);
+            ptr = 0 ;
+        }
+
+        inline void setsockopt (int option_, const void *optval_,
+            size_t optvallen_)
+        {
+            int rc = zmq_setsockopt (ptr, option_, optval_, optvallen_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline void getsockopt (int option_, void *optval_,
+            size_t *optvallen_)
+        {
+            int rc = zmq_getsockopt (ptr, option_, optval_, optvallen_);
+            if (rc != 0)
+                throw error_t ();
+        }
+        
+        inline void bind (const char *addr_)
+        {
+            int rc = zmq_bind (ptr, addr_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline void unbind (const char *addr_)
+        {
+            int rc = zmq_unbind (ptr, addr_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline void connect (const char *addr_)
+        {
+            int rc = zmq_connect (ptr, addr_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline void disconnect (const char *addr_)
+        {
+            int rc = zmq_disconnect (ptr, addr_);
+            if (rc != 0)
+                throw error_t ();
+        }
+
+        inline bool connected()
+        {
+            return(ptr != NULL);
+        }
+        
+        inline size_t send (const void *buf_, size_t len_, int flags_ = 0)
+        {
+            int nbytes = zmq_send (ptr, buf_, len_, flags_);
+            if (nbytes >= 0)
+                return (size_t) nbytes;
+            if (zmq_errno () == EAGAIN)
+                return 0;
+            throw error_t ();
+        }
+
+        inline bool send (message_t &msg_, int flags_ = 0)
+        {
+            int nbytes = zmq_msg_send (&(msg_.msg), ptr, flags_);
+            if (nbytes >= 0)
+                return true;
+            if (zmq_errno () == EAGAIN)
+                return false;
+            throw error_t ();
+        }
+
+        inline size_t recv (void *buf_, size_t len_, int flags_ = 0)
+        {
+            int nbytes = zmq_recv (ptr, buf_, len_, flags_);
+            if (nbytes >= 0)
+                return (size_t) nbytes;
+            if (zmq_errno () == EAGAIN)
+                return 0;
+            throw error_t ();
+        }
+
+        inline bool recv (message_t *msg_, int flags_ = 0)
+        {
+            int nbytes = zmq_msg_recv (&(msg_->msg), ptr, flags_);
+            if (nbytes >= 0)
+                return true;
+            if (zmq_errno () == EAGAIN)
+                return false;
+            throw error_t ();
+        }
+        
+    private:
+        void *ptr;
+        void *ctxptr;
+
+        socket_t (const socket_t&) ZMQ_DELETED_FUNCTION;
+        void operator = (const socket_t&) ZMQ_DELETED_FUNCTION;
+    };
+
+    class monitor_t
+    {
+    public:
+        monitor_t() : socketPtr(NULL) {}
+        virtual ~monitor_t() {}
+
+        void monitor(socket_t &socket, const char *addr_, int events = ZMQ_EVENT_ALL)
+        {
+            int rc = zmq_socket_monitor(socket.ptr, addr_, events);
+            if (rc != 0)
+                throw error_t ();
+
+            socketPtr = socket.ptr;
+            void *s = zmq_socket (socket.ctxptr, ZMQ_PAIR);
+            assert (s);
+
+            rc = zmq_connect (s, addr_);
+            assert (rc == 0);
+            
+            on_monitor_started();
+            
+            while (true) {
+                zmq_msg_t eventMsg;
+                zmq_msg_init (&eventMsg);
+                rc = zmq_recvmsg (s, &eventMsg, 0);
+                if (rc == -1 && zmq_errno() == ETERM)
+                    break;
+                assert (rc != -1);
+                zmq_event_t* event = static_cast<zmq_event_t*>(zmq_msg_data (&eventMsg));
+                
+#ifdef ZMQ_NEW_MONITOR_EVENT_LAYOUT
+                zmq_msg_t addrMsg;
+                zmq_msg_init (&addrMsg);
+                rc = zmq_recvmsg (s, &addrMsg, 0);
+                if (rc == -1 && zmq_errno() == ETERM)
+                    break;
+                assert (rc != -1);
+                const char* str = static_cast<const char*>(zmq_msg_data (&addrMsg));
+                std::string address(str, str + zmq_msg_size(&addrMsg));
+                zmq_msg_close (&addrMsg);
+#else
+                // Bit of a hack, but all events in the zmq_event_t union have the same layout so this will work for all event types.
+                std::string address = event->data.connected.addr;
+#endif
+
+#ifdef ZMQ_EVENT_MONITOR_STOPPED
+                if (event->event == ZMQ_EVENT_MONITOR_STOPPED)
+                    break;
+#endif
+
+                switch (event->event) {
+                case ZMQ_EVENT_CONNECTED:
+                    on_event_connected(*event, address.c_str());
+                    break;
+                case ZMQ_EVENT_CONNECT_DELAYED:
+                    on_event_connect_delayed(*event, address.c_str());
+                    break;
+                case ZMQ_EVENT_CONNECT_RETRIED:
+                    on_event_connect_retried(*event, address.c_str());
+                    break;
+                case ZMQ_EVENT_LISTENING:
+                    on_event_listening(*event, address.c_str());
+                    break;
+                case ZMQ_EVENT_BIND_FAILED:
+                    on_event_bind_failed(*event, address.c_str());
+                    break;
+                case ZMQ_EVENT_ACCEPTED:
+                    on_event_accepted(*event, address.c_str());
+                    break;
+                case ZMQ_EVENT_ACCEPT_FAILED:
+                    on_event_accept_failed(*event, address.c_str());
+                    break;
+                case ZMQ_EVENT_CLOSED:
+                    on_event_closed(*event, address.c_str());
+                    break;
+                case ZMQ_EVENT_CLOSE_FAILED:
+                    on_event_close_failed(*event, address.c_str());
+                    break;
+                case ZMQ_EVENT_DISCONNECTED:
+                    on_event_disconnected(*event, address.c_str());
+                    break;
+                default:
+                    on_event_unknown(*event, address.c_str());
+                    break;
+                }
+                zmq_msg_close (&eventMsg);
+            }
+            zmq_close (s);
+            socketPtr = NULL;
+        }
+
+#ifdef ZMQ_EVENT_MONITOR_STOPPED
+        void abort()
+        {
+            if (socketPtr)
+                zmq_socket_monitor(socketPtr, NULL, 0);
+        }
+#endif
+        virtual void on_monitor_started() {}
+        virtual void on_event_connected(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_connect_delayed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_connect_retried(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_listening(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_bind_failed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_accepted(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_accept_failed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_closed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_close_failed(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_disconnected(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+        virtual void on_event_unknown(const zmq_event_t &event_, const char* addr_) { (void)event_; (void)addr_; }
+    private:
+        void* socketPtr;
+    };
+}
+
+#endif

--- a/rflib/types/TLV.hh
+++ b/rflib/types/TLV.hh
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 #include <boost/shared_array.hpp>
-#include <mongo/client/dbclient.h>
+#include <mongo/bson/bson.h>
 
 #include "types/MACAddress.h"
 #include "types/IPAddress.h"

--- a/rfserver/MemoryTable.py
+++ b/rfserver/MemoryTable.py
@@ -1,0 +1,37 @@
+from rflib.defs import *
+
+class MemoryTable:
+    def __init__(self, name, address=None):
+        self.name = name
+        self._next_id = 1000
+        self._data = {}
+
+    def get_dicts(self, **kwargs):
+        if len(kwargs) == 0:
+            return self._data.values()
+
+        results = []
+        for d in self._data.itervalues():
+            add = True
+            for (k,v) in kwargs.iteritems():
+                if k not in d or d[k] != v:
+                    add = False
+                    break
+            if add:
+                results.append(d)
+        return results
+
+    def set_dict(self, d):
+        if '_id' not in d:
+            self._next_id += 1
+            d['_id'] = self._next_id
+        _id = d['_id']
+        self._data[_id] = d
+        return _id
+
+    def remove_id(self, _id):
+        if _id in self._data:
+            del self._data[_id]
+
+    def clear(self):
+        self._data = {}

--- a/rfserver/MongoTable.py
+++ b/rfserver/MongoTable.py
@@ -1,0 +1,24 @@
+import pymongo as mongo
+
+from rflib.defs import *
+from rflib.ipc.MongoIPC import format_address
+
+class MongoTable:
+    def __init__(self, name, address=MONGO_ADDRESS):
+        self.name = name
+        self.address = format_address(address)
+        self.connection = mongo.Connection(*self.address)
+        self.data = self.connection[MONGO_DB_NAME][name]
+
+    def get_dicts(self, **kwargs):
+        return self.data.find(kwargs)
+
+    def set_dict(self, d):
+        # TODO: enforce (*_id, *_port) uniqueness restriction
+        return self.data.save(d)
+
+    def remove_id(self, _id):
+        self.data.remove(_id)
+
+    def clear(self):
+        self.data.remove()

--- a/rfserver/rftable.py
+++ b/rfserver/rftable.py
@@ -1,7 +1,9 @@
-import pymongo as mongo
-
 from rflib.defs import *
-from rflib.ipc.MongoIPC import format_address
+
+if DB_TYPE == 'memory':
+    from MemoryTable import MemoryTable as TableBase
+else:
+    from MongoTable import MongoTable as TableBase
 
 RFENTRY_IDLE_VM_PORT = 1
 RFENTRY_IDLE_DP_PORT = 2
@@ -16,8 +18,7 @@ RFCONFIGENTRY = 1
 RFISLCONFENTRY = 2
 RFISLENTRY = 3
 
-
-class MongoTableEntryFactory:
+class EntryFactory:
     @staticmethod
     def make(type_):
         if type_ == RFENTRY:
@@ -29,34 +30,25 @@ class MongoTableEntryFactory:
         elif type_ == RFISLCONFENTRY:
             return RFISLConfEntry()
 
-
-class MongoTable:
-    def __init__(self, address, name, entry_type):
-        self.address = format_address(address)
-        self.connection = mongo.Connection(*self.address)
-        self.data = self.connection[MONGO_DB_NAME][name]
+class EntryTable(TableBase):
+    def __init__(self, name, entry_type):
+        TableBase.__init__(self, name)
         self.entry_type = entry_type
 
     def get_entries(self, **kwargs):
-        for (k, v) in kwargs.items():
-            kwargs[k] = str(v)
-        results = self.data.find(kwargs)
+        results = self.get_dicts(**kwargs)
         entries = []
         for result in results:
-            entry = MongoTableEntryFactory.make(self.entry_type)
+            entry = EntryFactory.make(self.entry_type)
             entry.from_dict(result)
             entries.append(entry)
         return entries
 
     def set_entry(self, entry):
-        # TODO: enforce (*_id, *_port) uniqueness restriction
-        entry.id = self.data.save(entry.to_dict())
+        entry.id = self.set_dict(entry.to_dict())
 
     def remove_entry(self, entry):
-        self.data.remove(entry.id)
-
-    def clear(self):
-        self.data.remove()
+        self.remove_id(entry.id)
 
     def __str__(self):
         s = ""
@@ -65,9 +57,9 @@ class MongoTable:
         return s.strip("\n")
 
 
-class RFTable(MongoTable):
-    def __init__(self, address=MONGO_ADDRESS):
-        MongoTable.__init__(self, address, RFTABLE_NAME, RFENTRY)
+class RFTable(EntryTable):
+    def __init__(self):
+        EntryTable.__init__(self, RFTABLE_NAME, RFENTRY)
 
     def get_entry_by_vm_port(self, vm_id, vm_port):
         result = self.get_entries(vm_id=vm_id,
@@ -98,9 +90,9 @@ class RFTable(MongoTable):
         return bool(self.get_dp_entries(ct_id, dp_id))
 
 
-class RFConfig(MongoTable):
-    def __init__(self, ifile, address=MONGO_ADDRESS):
-        MongoTable.__init__(self, address, RFCONFIG_NAME, RFCONFIGENTRY)
+class RFConfig(EntryTable):
+    def __init__(self, ifile):
+        EntryTable.__init__(self, RFCONFIG_NAME, RFCONFIGENTRY)
         # TODO: perform validation of config
         configfile = file(ifile)
         lines = configfile.readlines()[1:]
@@ -125,10 +117,9 @@ class RFConfig(MongoTable):
             return None
         return result[0]
 
-
-class RFISLTable(MongoTable):
-    def __init__(self, address=MONGO_ADDRESS):
-        MongoTable.__init__(self, address, RFISL_NAME, RFISLENTRY)
+class RFISLTable(EntryTable):
+    def __init__(self):
+        EntryTable.__init__(self, RFISL_NAME, RFISLENTRY)
 
     def get_entry_by_addr(self, ct_id, dp_id, dp_port, eth_addr):
         result = self.get_entries(ct_id=ct_id, dp_id=dp_id, dp_port=dp_port,
@@ -150,10 +141,9 @@ class RFISLTable(MongoTable):
     def is_dp_registered(self, ct_id, dp_id):
         return bool(self.get_dp_entries(ct_id, dp_id))
 
-
-class RFISLConf(MongoTable):
-    def __init__(self, ifile, address=MONGO_ADDRESS):
-        MongoTable.__init__(self, address, RFISLCONF_NAME, RFISLCONFENTRY)
+class RFISLConf(EntryTable):
+    def __init__(self, ifile):
+        EntryTable.__init__(self, RFISLCONF_NAME, RFISLCONFENTRY)
         # TODO: perform validation of config
         try:
             internalfile = file(ifile)
@@ -181,8 +171,7 @@ def load_from_dict(src, obj, attr):
 
 
 def pack_into_dict(dest, obj, attr):
-    value = getattr(obj, attr)
-    dest[attr] = "" if value is None else str(value)
+    dest[attr] = getattr(obj, attr)
 
 
 class RFEntry:
@@ -261,22 +250,17 @@ class RFEntry:
                "dp_id: %s\ndp_port: %s\n"\
                "vs_id: %s\nvs_port: %s\n"\
                "eth_addr: %s\nct_id: %s\n"\
-               "status:%s" % (str(self.vm_id),
-                              str(self.vm_port),
-                              str(self.dp_id),
-                              str(self.dp_port),
-                              str(self.vs_id),
-                              str(self.vs_port),
-                              str(self.eth_addr),
-                              str(self.ct_id),
-                              str(self.get_status()))
+               "status:%s" % (self.vm_id,
+                              self.vm_port,
+                              self.dp_id,
+                              self.dp_port,
+                              self.vs_id,
+                              self.vs_port,
+                              self.eth_addr,
+                              self.ct_id,
+                              self.get_status())
 
     def from_dict(self, data):
-        for k, v in data.items():
-            if str(v) is "":
-                data[k] = None
-            elif k != "_id" and k != "eth_addr":  # All our data is int
-                data[k] = int(v)
         self.id = data["_id"]
         load_from_dict(data, self, "vm_id")
         load_from_dict(data, self, "vm_port")
@@ -321,9 +305,9 @@ class RFISLEntry:
         return "vm_id: %s "\
                "ct_id: %s dp_id: %s dp_port: %s eth_addr: %s"\
                "rem_ct: %s rem_id: %s rem_port: %s rem_addr: %s"\
-               % (str(self.vm_id), str(self.ct_id),
-                  str(self.dp_id), str(self.dp_port), self.eth_addr,
-                  str(self.rem_ct), str(self.rem_id), str(self.rem_port),
+               % (self.vm_id, self.ct_id,
+                  self.dp_id, self.dp_port, self.eth_addr,
+                  self.rem_ct, self.rem_id, self.rem_port,
                   self.rem_eth_addr)
 
     def make_idle(self, type_):
@@ -375,11 +359,6 @@ class RFISLEntry:
             return RFISL_ACTIVE
 
     def from_dict(self, data):
-        for k, v in data.items():
-            if str(v) is "":
-                data[k] = None
-            elif k != "_id" and not k.endswith("eth_addr"):
-                data[k] = int(v)
         self.id = data["_id"]
         load_from_dict(data, self, "vm_id")
         load_from_dict(data, self, "ct_id")
@@ -426,20 +405,15 @@ class RFISLConfEntry:
         return "vm_id: %s "\
                "ct_id: %s dp_id: %s dp_port: %s eth_addr: %s"\
                "rem_ct: %s rem_id: %s rem_port: %s rem_addr: %s"\
-               % (str(self.vm_id), str(self.ct_id),
-                  str(self.dp_id), str(self.dp_port), self.eth_addr,
-                  str(self.rem_ct), str(self.rem_id), str(self.rem_port),
+               % (self.vm_id, self.ct_id,
+                  self.dp_id, self.dp_port, self.eth_addr,
+                  self.rem_ct, self.rem_id, self.rem_port,
                   self.rem_eth_addr)
 
     def get_status(self):
         return RFENTRY_ACTIVE
 
     def from_dict(self, data):
-        for k, v in data.items():
-            if str(v) is "":
-                data[k] = None
-            elif k != "_id" and not k.endswith("eth_addr"):
-                data[k] = int(v)
         self.id = data["_id"]
         load_from_dict(data, self, "vm_id")
         load_from_dict(data, self, "ct_id")
@@ -480,16 +454,11 @@ class RFConfigEntry:
     def __str__(self):
         return "vm_id: %s vm_port: %s "\
                "dp_id: %s dp_port: %s "\
-               "ct_id: %s" % (str(self.vm_id), str(self.vm_port),
-                              str(self.dp_id), str(self.dp_port),
-                              str(self.ct_id))
+               "ct_id: %s" % (self.vm_id, self.vm_port,
+                              self.dp_id, self.dp_port,
+                              self.ct_id)
 
     def from_dict(self, data):
-        for k, v in data.items():
-            if str(v) is "":
-                data[k] = None
-            elif k != "_id":  # All our data is int
-                data[k] = int(v)
         self.id = data["_id"]
         load_from_dict(data, self, "vm_id")
         load_from_dict(data, self, "vm_port")

--- a/rftest/rftest1
+++ b/rftest/rftest1
@@ -8,34 +8,55 @@ fi
 PROTOCOLS="OpenFlow10,OpenFlow12,OpenFlow13"
 SCRIPT_NAME="rftest1"
 LXCDIR=/var/lib/lxc
+USE_MONGO=1
 MONGODB_CONF=/etc/mongodb.conf
 MONGODB_PORT=27017
-MONGODB_ADDR="192.168.10.1"
+VM_ADDR="192.168.10.1"
 CONTROLLER_PORT=6633
 RF_HOME=..
 export PATH=$PATH:/usr/local/bin:/usr/local/sbin
 export PYTHONPATH=$PYTHONPATH:$RF_HOME
 
-ACTION=""
-case "$1" in
---help)
-    echo "$0"
-    echo "Options: "
+usage() {
+    echo "$0 [-hrz] [--pox] [--ryu]"
+    echo "Script Actions:"
     echo "    --pox: run using POX (default)"
-    echo "    --ryu: run using NOX"
-    echo "    --reset: stop running and clear data from previous executions"
-    exit
-    ;;
---reset)
-    ACTION="RESET"
-    ;;
---ryu)
-    ACTION="RYU"
-    ;;
-*)
-    ACTION="POX"
-    ;;
-esac
+    echo "    --ryu: run using RYU"
+    echo "    -r, --reset: stop running and clear data from previous executions"
+    echo
+    echo "General Options:"
+    echo "    -h, --help: Display this message and exit"
+    echo "    -z, --zeromq: Use ZeroMQ for IPC instead of MongoDB"
+}
+
+ACTION="POX"
+while test $# -gt 0
+do
+    case "$1" in
+    --pox)
+        ACTION="RYU"
+        ;;
+    --ryu)
+        ACTION="RYU"
+        ;;
+    -r | --reset)
+        ACTION="RESET"
+        ;;
+    -z | --zeromq)
+        USE_MONGO=0
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+
+    shift
+done
 
 cd $RF_HOME
 
@@ -90,13 +111,15 @@ reset() {
     done
 
     echo_bold "-> Deleting data from previous runs...";
-    mongo db --quiet --eval "
-        db.getCollection('rftable').drop();
-        db.getCollection('rfconfig').drop();
-        db.getCollection('rfstats').drop();
-        db.getCollection('rfclient<->rfserver').drop();
-        db.getCollection('rfserver<->rfproxy').drop();
-    "
+    if [ $USE_MONGO -eq 1 ]; then
+        mongo db --quiet --eval "
+            db.getCollection('rftable').drop();
+            db.getCollection('rfconfig').drop();
+            db.getCollection('rfstats').drop();
+            db.getCollection('rfclient<->rfserver').drop();
+            db.getCollection('rfserver<->rfproxy').drop();
+        "
+    fi
     rm -rf /var/lib/lxc/rfvm1/rootfs/opt/rfclient;
 }
 reset 1
@@ -104,13 +127,15 @@ trap "reset 0; exit 0" INT
 
 if [ "$ACTION" != "RESET" ]; then
     echo_bold "-> Setting up the management bridge (lxcbr0)..."
-    ifconfig lxcbr0 $MONGODB_ADDR up
+    ifconfig lxcbr0 $VM_ADDR up
     ovs-vsctl --may-exist add-port lxcbr0 rfvm1.0
 
-    echo_bold "-> Setting up MongoDB..."
-    sed -i "/bind_ip/c\bind_ip = 127.0.0.1,$MONGODB_ADDR" $MONGODB_CONF
-    service mongodb restart
-    wait_port_listen $MONGODB_PORT
+    if [ $USE_MONGO -eq 1 ]; then
+        echo_bold "-> Setting up MongoDB..."
+        sed -i "/bind_ip/c\bind_ip = 127.0.0.1,$VM_ADDR" $MONGODB_CONF
+        service mongodb restart
+        wait_port_listen $MONGODB_PORT
+    fi
 
     echo_bold "-> Starting the rfvm1 virtual machine..."
     # Create the rfclient dir
@@ -122,7 +147,7 @@ if [ "$ACTION" != "RESET" ]; then
     # We sleep for a few seconds to wait for the interfaces to go up
     echo "#!/bin/sh" > /var/lib/lxc/rfvm1/rootfs/root/run_rfclient.sh
     echo "sleep 3" >> /var/lib/lxc/rfvm1/rootfs/root/run_rfclient.sh
-    echo "/opt/rfclient/rfclient -a $MONGODB_ADDR 2>&1 >/var/log/rfclient.log" >> /var/lib/lxc/rfvm1/rootfs/root/run_rfclient.sh
+    echo "/opt/rfclient/rfclient 2>&1 >/var/log/rfclient.log" >> /var/lib/lxc/rfvm1/rootfs/root/run_rfclient.sh
 
     chmod +x /var/lib/lxc/rfvm1/rootfs/root/run_rfclient.sh
 


### PR DESCRIPTION
This set of patches:

Enables ZeroMQ as a message bus (as an alternative to MongoDB)
Supports in-memory tables for data storage (as an alternative to MongoDB)
A wrinkle is that a C++ BSON data library is needed. The first patch pulls this code from the mongodb cxx driver.
