### PR TITLE
rfclient: apply setsockopt(SO_RCVBUFFORCE) to netlink socket for routes

### DIFF
--- a/rfclient/FlowTable.cc
+++ b/rfclient/FlowTable.cc
@@ -66,7 +66,7 @@ void FlowTable::operator()() {
             syslog(LOG_NOTICE, "Netlink interface enabled");
             rtnl_open(&rth, RTMGRP_IPV4_ROUTE | RTMGRP_IPV6_ROUTE |
                             RTMGRP_IPV4_MROUTE | RTMGRP_IPV6_MROUTE);
-            int rs = setsockopt(rthNeigh.fd, SOL_SOCKET, SO_RCVBUFFORCE, &nl_buffersize, sizeof(nl_buffersize));
+            int rs = setsockopt(rth.fd, SOL_SOCKET, SO_RCVBUFFORCE, &nl_buffersize, sizeof(nl_buffersize));
             if (rs != 0) {
                 syslog(LOG_CRIT, "cannot set socket size for routes: %d", errno);
                 exit(rs);


### PR DESCRIPTION
The receive buffer was being forced twice on the neighbour update socket.
The second call should have been asserting the receive buffer increase
on the route update socket.

Without this, large routing update bursts were resulting in dropped
netlink messages, and thus missing FIB updates in the OF dataplane.

These dropped netlink messages can be seen by running:
  $ cat /proc/net/netlink
and looking for non-zero values in the "Drops" column.

Signed-off-by: Stacey Sheldon stac@corsa.com
