### PR TITLE
Added the OSPF constant for enabling rftest2 in vandervecken branch

### DIFF
--- a/rflib/defs.h
+++ b/rflib/defs.h
@@ -61,6 +61,8 @@ typedef enum port_config_type {
 #define TPORT_BGP 0x00B3
 #define OFPP_CONTROLLER 0xFFFFFFFD
 
+#define IPPROTO_OSPF 0x59
+
 #define CONTROLLER_GROUP 1
 
 #endif /* __DEFS_H__ */


### PR DESCRIPTION
This has the missing diff for pull request #15 
