### PR TITLE
rfserver: better support for multiple vendors using multi-table datapaths

### DIFF
--- a/projectw.sh
+++ b/projectw.sh
@@ -10,6 +10,11 @@ DPPORTNET=172.31
 DPPORTNETV6=fc00::
 DPPORTS=2
 SWITCH1DPID=0x99
+# Multi-table datapaths are listed by 'DPID/vendor' to allow the proper
+# flow mods to be sent for each vendor's pipeline.
+# Examples:
+#    MULTITABLEDPS="0x99/corsa"
+#    MULTITABLEDPS="0x99/noviflow"
 MULTITABLEDPS="''"
 SATELLITEDPS="''"
 


### PR DESCRIPTION
Until now, any multi-table datapath was assumed to be NoviFlow and other
vendors had to patch rfserver.py so that their custom RouteModTranslator
subclass would be used.

New format for --multitabledps option is:

```
dpid1/vendor1,dpid2/vendor2,...
```

This allows the user to associate the vendor (and thus the appropriate
RouteModTranslator subclass) with a given datapath.
