### PR TITLE
rfserver: ensure that OFPVID_PRESENT is set in the set_vlan_id action

### DIFF
--- a/rfserver/rfserver.py
+++ b/rfserver/rfserver.py
@@ -371,6 +371,7 @@ class CorsaMultitableRouteModTranslator(RouteModTranslator):
         return rms
 
     def _send_rm_with_matches(self, rm, out_port, entries):
+        OFPVID_PRESENT = 0x1000
         rms = []
         for entry in entries:
             if out_port != entry.dp_port:
@@ -386,7 +387,7 @@ class CorsaMultitableRouteModTranslator(RouteModTranslator):
                             dst_eth = action.get_value()
                         elif action_type == 'RFAT_SWAP_VLAN_ID':
                             vlan_id = action.get_value()
-                            action = Action.SET_VLAN_ID(vlan_id)
+                            action = Action.SET_VLAN_ID(vlan_id | OFPVID_PRESENT)
                         rm.add_action(action)
                     if dst_eth not in self.actions_to_groupid:
                         self.last_groupid += 1


### PR DESCRIPTION
The OFPVID_PRESENT bit was not being set in the set_vlan_id actions in the group table entries which is in violation of the OF 1.3.4 spec section 7.2.5 (Action Structures) and was resulting in the group-mod requests being refused:

```
The value in the payload of the OXM TLV must be valid, in particular the OFPVID_PRESENT bit must be set in OXM_OF_VLAN_VID set-field actions.
```

This behaviour seems to have changed over time since I know this was working (pre-patch) on older Vandervecken installations.  This issue was observed on a new installation.  More investigation is required to determine why the behaviour changed and to determine if it is also affecting other switches.
